### PR TITLE
Added field "phase" to the ApplicationSpec

### DIFF
--- a/hack/install.yaml
+++ b/hack/install.yaml
@@ -79,6 +79,11 @@ spec:
               type: array
             description:
               type: string
+            phase:
+              type: string
+              enum:
+              - Assembly
+              - Assembled
             info:
               items:
                 properties:

--- a/hack/sample/application.yaml
+++ b/hack/sample/application.yaml
@@ -19,6 +19,7 @@ spec:
       kind: StatefulSet
   version: "4.9.4"
   description: "WordPress is open source software you can use to create a beautiful website, blog, or app."
+  phase: "Assembled"
   maintainers:
     - name: Kenneth Owens
       email: kow3ns@github.com

--- a/pkg/apis/app/v1alpha1/application_types.go
+++ b/pkg/apis/app/v1alpha1/application_types.go
@@ -58,6 +58,9 @@ type ApplicationSpec struct {
 
 	// Notes contain a human readable snippets intended as a quick start for the users of the Application.
 	Notes string `json:"notes,omitempty"`
+
+	// Phase represents the current phase of the application.
+	Phase ApplicationPhase `json:"phase,omitempty"`
 }
 
 // ApplicationStatus defines controllers the observed state of Application
@@ -97,6 +100,17 @@ type InfoItem struct {
 	// Value is human readable content.
 	Value string `json:"value,omitempty"`
 }
+
+type ApplicationPhase string
+
+const (
+	// Used to indicate that not all of application's components
+	// have been deployed yet.
+	Assembly ApplicationPhase = "Assembly"
+	// Used to indicate that all of application's components
+	// have alraedy been deployed.
+	Assembled ApplicationPhase = "Assembled"
+)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/app/v1alpha1/zz_generated.kubebuilder.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.kubebuilder.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package v1alpha1
 
 import (
@@ -166,6 +181,9 @@ var (
 											Type: "string",
 										},
 									},
+								},
+								"phase": v1beta1.JSONSchemaProps{
+									Type: "string",
 								},
 								"selector": v1beta1.JSONSchemaProps{
 									Type: "object",

--- a/pkg/inject/zz_generated.kubebuilder.go
+++ b/pkg/inject/zz_generated.kubebuilder.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package inject
 
 import (


### PR DESCRIPTION
The field is to be used by deployers (either automated or manual) to indicate whether all of application's resources have already been deployed.