### PR TITLE
Dropped additionalProperties from validation code

### DIFF
--- a/hack/install.yaml
+++ b/hack/install.yaml
@@ -134,8 +134,6 @@ spec:
                     type: object
                   type: array
                 matchLabels:
-                  additionalProperties:
-                    type: string
                   type: object
               type: object
             type:


### PR DESCRIPTION
Validating map fields is not supported in kubernetes <=1.10
https://github.com/kubernetes/kubernetes/pull/62333