### PR TITLE
Soft-suggesting markdown for formatting

### DIFF
--- a/pkg/apis/app/v1alpha1/application_types.go
+++ b/pkg/apis/app/v1alpha1/application_types.go
@@ -38,6 +38,7 @@ type ApplicationSpec struct {
 	Version string `json:"version,omitempty"`
 
 	// Description is a brief string description of the Application.
+	// Should contain plain text or plain-text-friendly markup (eg. markdown).
 	Description string `json:"description,omitempty"`
 
 	// Maintainers is an optional list of maintainers of the application. The maintainers in this list maintain the
@@ -58,6 +59,7 @@ type ApplicationSpec struct {
 	Links []Link `json:"links,omitempty"`
 
 	// Notes contain a human readable snippets intended as a quick start for the users of the Application.
+	// Should contain plain text or plain-text-friendly markup (eg. markdown).
 	Notes string `json:"notes,omitempty"`
 
 	// AssemblyPhase represents the current phase of the application's assembly.


### PR DESCRIPTION
The textual fields will inevitably need some formatting (lists, code samples etc.).

Rather than forcing any specific markup language, the Application type should suggest using one that's possible to render
in plain text, with a nod towards markdown as example of this.