### PR TITLE
Encouraging using markdown for notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ aggregation and display of all the components in the Application.
     <tr>
         <td>spec.descriptor.notes</td>
         <td>string</td>
-        <td>Notes contain a human readable snippets intended as a quick start for the users of the
-        Application.</td>
+        <td>Notes contain human readable snippets intended as a quick start for the users of the
+        Application. They may be plain text or <a href="spec.commonmark.org">CommonMark</a> markdown.</td>
     </tr>
     <tr>
         <td>spec.assemblyPhase</td>

--- a/pkg/apis/app/v1beta1/application_types.go
+++ b/pkg/apis/app/v1beta1/application_types.go
@@ -51,6 +51,7 @@ type Descriptor struct {
 	Links []Link `json:"links,omitempty"`
 
 	// Notes contain a human readable snippets intended as a quick start for the users of the Application.
+	// CommonMark markdown syntax may be used for rich text representation.
 	Notes string `json:"notes,omitempty"`
 }
 


### PR DESCRIPTION
This is an updated version of https://github.com/kubernetes-sigs/application/pull/48 that lives in my own fork rather than a fork in the upstream repo.

Addressed the comments:

1. Dropped suggestion from the decription field.
1. Made the encouragement for explicit.

@mattfarina (github doesn't let me add you to reviewers)