### PR TITLE
Update docs & examples to follow K8s recommended application labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,9 @@ aggregation and display of all the components in the Application.
     <tr>
         <td>spec.selector</td>
         <td><a href=https://kubernetes.io/docs/concepts/overview/working-with-objects/labels>LabelSelector</a></td>
-        <td>The selector is used to match resources that belong to the Application. All of the applications
-        resources should have labels such that they match this selector. Users should use the
-        <i>app.kubernetes.io/name</i> label on all components of the Application and set the selector to
-        match this label. For instance, <i>{"matchLabels": [{"app.kubernetes.io/name": "my-cool-app"}]}</i> should be
+        <td>This selector is used to match resources that belong to the Application. All of the applications
+        resources should have labels such that they match this selector. Users are encouraged to follow the
+        <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels">recommended labels</a> on all components of the Application and set the selector to match these labels. For example, <i>{"matchLabels": [{"app.kubernetes.io/instance": "my-cool-app"}]}</i> could be
         used as the selector for an Application named "my-cool-app", and each component should contain a label that
         matches.</td>
     </tr>
@@ -190,12 +189,13 @@ kind: Application
 metadata:
   name: "wordpress-01"
   labels:
-    app.kubernetes.io/name: "wordpress-01"
+    app.kubernetes.io/name: "wordpress"
+    app.kubernetes.io/instance: "wordpress-01"
     app.kubernetes.io/version: "3"
 spec:
   selector:
     matchLabels:
-     app.kubernetes.io/name: "wordpress-01"
+     app.kubernetes.io/instance: "wordpress-01"
   componentKinds:
     - group: core
       kind: Service
@@ -232,10 +232,11 @@ spec:
 Notice that each Service and StatefulSet is labeled such that Application's Selector matches the labels.
 
 ```yaml
-app.kubernetes.io/name: "wordpress-01"
+app.kubernetes.io/instance: "wordpress-01"
 ```
 
-The additional labels on the Applications components come from the recommended application labels and annotations.
+The additional labels on the Applications components come from the
+[recommended application labels and annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels).
 
 You can use the standard `kubectl` verbs (e.g. `get`, `apply`, `create`, `delete`, `list`, `watch`) to interact with
 an Application specified in a manifest.

--- a/docs/example.yaml
+++ b/docs/example.yaml
@@ -3,12 +3,12 @@ kind: Application
 metadata:
   name: "wordpress-01"
   labels:
-    app.kubernetes.io/name: "wordpress-01"
+    app.kubernetes.io/instance: "wordpress-01"
 spec:
   type: "wordpress"
   selector:
     matchLabels:
-     app.kubernetes.io/name: "wordpress-01"
+     app.kubernetes.io/instance: "wordpress-01"
   componentKinds:
     - group: core
       kind: Service
@@ -46,7 +46,8 @@ kind: Service
 metadata:
   name: wordpress-mysql-hsvc
   labels:
-    app.kubernetes.io/name: "wordpress-01"
+    app.kubernetes.io/name: "wordpress"
+    app.kubernetes.io/instance: "wordpress-01"
     app.kubernetes.io/version: "3"
     app.kubernetes.io/component: "mysql-hsvc"
     app.kubernetes.io/tier: "backend"
@@ -54,7 +55,8 @@ spec:
   ports:
     - port: 3306
   selector:
-    app.kubernetes.io/name: "wordpress-01"
+    app.kubernetes.io/name: "wordpress"
+    app.kubernetes.io/instance: "wordpress-01"
     app.kubernetes.io/component: "mysql-rdbms"
   clusterIP: None
 ---
@@ -63,14 +65,16 @@ kind: StatefulSet
 metadata:
   name: wordpress-mysql
   labels:
-    app.kubernetes.io/name: "wordpress-01"
+    app.kubernetes.io/name: "wordpress"
+    app.kubernetes.io/instance: "wordpress-01"
     app.kubernetes.io/version: "3"
     app.kubernetes.io/component: "mysql-rdbms"
     app.kubernetes.io/tier: "backend"
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: "wordpress-01"
+      app.kubernetes.io/name: "wordpress"
+      app.kubernetes.io/instance: "wordpress-01"
       app.kubernetes.io/component: "mysql-rdbms"
       app.kubernetes.io/tier: "backend"
   replicas: 1
@@ -78,7 +82,8 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "wordpress-01"
+        app.kubernetes.io/name: "wordpress"
+        app.kubernetes.io/instance: "wordpress-01"
         app.kubernetes.io/component: "mysql-rdbms"
         app.kubernetes.io/tier: "backend"
     spec:
@@ -111,7 +116,8 @@ kind: Service
 metadata:
   name: wordpress-webserver-svc
   labels:
-    app.kubernetes.io/name: "wordpress-01"
+    app.kubernetes.io/name: "wordpress"
+    app.kubernetes.io/instance: "wordpress-01"
     app.kubernetes.io/version: "3"
     app.kubernetes.io/component: "wordpress-svc"
     app.kubernetes.io/tier: "frontend"
@@ -119,7 +125,8 @@ spec:
   ports:
     - port: 80
   selector:
-    app.kubernetes.io/name: "wordpress-01"
+    app.kubernetes.io/name: "wordpress"
+    app.kubernetes.io/instance: "wordpress-01"
     app.kubernetes.io/component: "wordpress-webserver"
   type: LoadBalancer
 ---
@@ -128,7 +135,8 @@ kind: Service
 metadata:
   name: wordpress-webserver-hsvc
   labels:
-    app.kubernetes.io/name: "wordpress-01"
+    app.kubernetes.io/name: "wordpress"
+    app.kubernetes.io/instance: "wordpress-01"
     app.kubernetes.io/version: "3"
     app.kubernetes.io/component: "wordpress-hsvc"
     app.kubernetes.io/tier: "frontend"
@@ -136,8 +144,9 @@ spec:
   ports:
     - port: 3306
   selector:
-     app.kubernetes.io/name: "wordpress-01"
-     app.kubernetes.io/component: "wordpress-webserver"
+    app.kubernetes.io/name: "wordpress"
+    app.kubernetes.io/instance: "wordpress-01"
+    app.kubernetes.io/component: "wordpress-webserver"
   clusterIP: None
 ---
 apiVersion: apps/v1
@@ -145,7 +154,8 @@ kind: StatefulSet
 metadata:
   name: wordpress-webserver
   labels:
-    app.kubernetes.io/name: "wordpress-01"
+    app.kubernetes.io/name: "wordpress"
+    app.kubernetes.io/instance: "wordpress-01"
     app.kubernetes.io/version: "3"
     app.kubernetes.io/component: "wordpress-webserver"
     app.kubernetes.io/tier: "frontend"
@@ -156,12 +166,14 @@ spec:
   serviceName: wordpress-webserver-hsvc
   selector:
     matchLabels:
-      app.kubernetes.io/name: "wordpress-01"
+      app.kubernetes.io/name: "wordpress"
+      app.kubernetes.io/instance: "wordpress-01"
       app.kubernetes.io/component: "wordpress-webserver"
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "wordpress-01"
+        app.kubernetes.io/name: "wordpress"
+        app.kubernetes.io/instance: "wordpress-01"
         app.kubernetes.io/version: "3"
         app.kubernetes.io/component: "wordpress-webserver"
         app.kubernetes.io/tier: "frontend"

--- a/hack/sample/application.yaml
+++ b/hack/sample/application.yaml
@@ -3,12 +3,13 @@ kind: Application
 metadata:
   name: "wordpress-01"
   labels:
-    app.kubernetes.io/name: "wordpress-01"
+    app.kubernetes.io/name: "wordpress"
+    app.kubernetes.io/instance: "wordpress-01"
     app.kubernetes.io/version: "3"
 spec:
   selector:
     matchLabels:
-     app.kubernetes.io/name: "wordpress-01"
+     app.kubernetes.io/instance: "wordpress-01"
   componentKinds:
     - group: core
       kind: Service


### PR DESCRIPTION
Per K8s documentation, `app.kubernetes.io/instance` would be more appropriate to use as a selector for an application object to match its resources, as opposed to `app.kubernetes.io/name`.