### PR TITLE
Fix kustomize 2.o error: Error: rawResources failed to read Resources…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install: manifests
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests
 	kubectl apply -f config/crds
-	kustomize build config/default | kubectl apply -f -
+	kustomize build config | kubectl apply -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests:

--- a/config/crds/app_v1beta1_application.yaml
+++ b/config/crds/app_v1beta1_application.yaml
@@ -22,6 +22,8 @@ spec:
           type: object
         spec:
           properties:
+            addOwnerRef:
+              type: boolean
             assemblyPhase:
               type: string
             componentKinds:

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # Adds namespace to all resources.
 namespace: application-system
 
@@ -18,10 +20,10 @@ namePrefix: application-
 # YAML string, with resources separated by document
 # markers ("---").
 resources:
-- ../rbac/rbac_role.yaml
-- ../rbac/rbac_role_binding.yaml
-- ../manager/manager.yaml
+- ./rbac/rbac_role.yaml
+- ./rbac/rbac_role_binding.yaml
+- ./manager/manager.yaml
 
-patches:
-- manager_image_patch.yaml
+patchesStrategicMerge:
+- ./default/manager_image_patch.yaml
 


### PR DESCRIPTION
…: Load from path

With latest version of (v2.0.2) of Kustomize, running `make deploy` ends up in error:
```
Error: rawResources failed to read Resources: Load from path ../rbac/rbac_role.yaml failed: security; file '../rbac/rbac_role.yaml' is not in or below '/Users/corinne/workspace/go/src/github.com/kubernetes-sigs/application/config/default'
```

Moving the `kustomize.yaml` file one folder up solves the issue.