### PR TITLE
Make KindMatchError (result of bad GVK config in crd) less fatal

### DIFF
--- a/pkg/genericreconciler/genericreconciler.go
+++ b/pkg/genericreconciler/genericreconciler.go
@@ -60,6 +60,13 @@ func (gr *Reconciler) observe(observables ...resource.Observable) (*resource.Obj
 						resources = append(resources, resource.Object{Obj: item.(metav1.Object)})
 					}
 				}
+			} else {
+				// Ignore KindMatchError - user input error
+				if kindMatchErr, ok := err.(*meta.NoKindMatchError); ok {
+					// Record it and make it less fatal
+					log.Printf("   >>>ERR listing: %s, %s", kindMatchErr.GroupKind, err.Error())
+					err = nil
+				}
 			}
 		} else {
 			var obj metav1.Object = obs.Obj.(metav1.Object)


### PR DESCRIPTION
Currently any error listing is bubbled up and loop is aborted.
This fix logs KindMatchError (user input error) and does not abort the loop.
This is to make the controller resilient to usererrors while allowing functionality to prevail.

Fixes #105 