### PR TITLE
Avoid observe after mutating

### DIFF
--- a/pkg/genericreconciler/genericreconciler.go
+++ b/pkg/genericreconciler/genericreconciler.go
@@ -219,15 +219,6 @@ func (gr *Reconciler) ObserveAndMutate(crname string, c component.Component, sta
 		if err != nil {
 			return emptybag, emptybag, fmt.Errorf("Failed mutating resources: %s", err.Error())
 		}
-
-		// Get observables
-		observables := c.Observables(gr.Scheme, c.CR, c.Labels(), expected)
-
-		// Observe observables
-		observed, err = gr.observe(observables...)
-		if err != nil {
-			return emptybag, emptybag, fmt.Errorf("Failed observing resources after mutation: %s", err.Error())
-		}
 	}
 
 	return expected, observed, err


### PR DESCRIPTION
Problem:
related to GoogleCloudPlatform/click-to-deploy#592

Issue:
1. An application was deployed from market place - application crd, sts, configmaps, ...
2. The application controller deleted a config map a few seconds later
3. This was an intermittent problem

Root Cause:
The ObserverAndMutate() code does this:
1. observed <- observe resources from cluster
2. expected <- controller's mutate(observed) [in this controller, expected = observed]
3. observed <- observe resources from cluster
4. reconcile expected and observed => observed between 1, 3 differs thereby differs from expected.
  
As part of reconcile we delete objects that are in observed but not in expected.

Solution:
The logic to observe after a mutation does not apply to this controller. It was from a different code.
We can safely remove the second observe()


