### PR TITLE
Add the status subresource to the application CRD

### DIFF
--- a/api/v1beta1/application_types.go
+++ b/api/v1beta1/application_types.go
@@ -302,6 +302,7 @@ const (
 )
 
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Application is the Schema for the applications API
 type Application struct {

--- a/config/crd/bases/app.k8s.io_applications.yaml
+++ b/config/crd/bases/app.k8s.io_applications.yaml
@@ -15,6 +15,8 @@ spec:
     plural: applications
     singular: application
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: Application is the Schema for the applications API
@@ -471,6 +473,8 @@ spec:
               format: int64
               type: integer
           type: object
+      required:
+      - spec
       type: object
   version: v1beta1
   versions:

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -69,11 +69,11 @@ func (r *ApplicationReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 	resources, err := r.updateComponents(ctx, &app)
 	newApplicationStatus := r.getNewApplicationStatus(ctx, &app, resources, err)
 
+	newApplicationStatus.ObservedGeneration = app.Generation
 	if equality.Semantic.DeepEqual(newApplicationStatus, &app.Status) {
 		return ctrl.Result{}, nil
 	}
 
-	newApplicationStatus.ObservedGeneration = app.Generation
 	err = r.updateApplicationStatus(ctx, req.NamespacedName, newApplicationStatus)
 	return ctrl.Result{}, err
 }
@@ -215,7 +215,7 @@ func (r *ApplicationReconciler) updateApplicationStatus(ctx context.Context, nn 
 			return err
 		}
 		original.Status = *status
-		if err := r.Update(ctx, original); err != nil {
+		if err := r.Client.Status().Update(ctx, original); err != nil {
 			return err
 		}
 		return nil

--- a/controllers/application_controller_test.go
+++ b/controllers/application_controller_test.go
@@ -246,7 +246,7 @@ var _ = Describe("Application Reconciler", func() {
 			instance := &appv1beta1.Application{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}, Spec: appv1beta1.ApplicationSpec{}}
 
 			// Create the Application object and expect the Reconcile and Deployment to be created
-			err := c.Create(context.TODO(), instance)
+			err := c.Create(ctx, instance)
 			// The instance object may not be a valid object because it might be missing some required fields.
 			// Please modify the instance object by adding required fields and then remove the following if statement.
 			if apierrors.IsInvalid(err) {
@@ -254,7 +254,7 @@ var _ = Describe("Application Reconciler", func() {
 				return
 			}
 			Expect(err).NotTo(HaveOccurred())
-			defer c.Delete(context.TODO(), instance)
+			defer c.Delete(ctx, instance)
 			var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
 			Eventually(requests, timeout).Should(Receive(Equal(expectedRequest)))
 		})
@@ -284,7 +284,7 @@ var _ = Describe("Application Reconciler", func() {
 			Expect(deployment.OwnerReferences).To(BeNil())
 			Expect(service.OwnerReferences).To(BeNil())
 
-			err := c.Create(context.TODO(), application)
+			err := c.Create(ctx, application)
 			Expect(err).NotTo(HaveOccurred())
 			waitForComponentsAddedToStatus(ctx, application, deployment.Name, service.Name)
 

--- a/e2e/test_e2e.sh
+++ b/e2e/test_e2e.sh
@@ -21,7 +21,7 @@ set -o pipefail
 source ./hack/scripts/common.sh
 
 
-K8S_VERSION="v1.16.2"
+K8S_VERSION="v1.16.4"
 
 fetch_kb_tools
 install_kind

--- a/hack/scripts/common.sh
+++ b/hack/scripts/common.sh
@@ -17,7 +17,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-k8s_version=1.11.0
+k8s_version=1.16.4
 goarch=amd64
 goos="unknown"
 tmp_root=/tmp


### PR DESCRIPTION
The status subresource was not added to the CRD definition, which makes
`r.Client.Status().Update(ctx, original)` return a 404 error with the
following message:
```
failed to update status of Application default/xxx:
applications.app.k8s.io "xxx" not found
```

This commit add the status subresource to the CRD definition.

It also moves application observedGeneration before we check whether
there are any changs to the status, which makes it possibly return
early.