### PR TITLE
Grant application-manager access to all resources

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -29,3 +29,10 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - list
+  - update


### PR DESCRIPTION
The application controller will list and update resources.
Without the access, the controller will fail to fetch or update the
resources with the following errors:
```
controllers.Application	deployments.apps is forbidden: User "system:serviceaccount:application-system:default" cannot list resource "deployments" in API group "apps" in the namespace "default"
```