### PR TITLE
Update the group of Service in the examples and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ spec:
     matchLabels:
      app.kubernetes.io/name: "wordpress-01"
   componentKinds:
-    - group: ""
+    - group: v1
       kind: Service
     - group: apps
       kind: StatefulSet

--- a/config/samples/app_v1beta1_application.yaml
+++ b/config/samples/app_v1beta1_application.yaml
@@ -13,7 +13,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: "wordpress-01"
   componentKinds:
-  - group: core
+  - group: v1
     kind: Service
   - group: apps
     kind: Deployment

--- a/controllers/application_controller_test.go
+++ b/controllers/application_controller_test.go
@@ -112,15 +112,15 @@ var _ = Describe("Application Reconciler", func() {
 					Kind:  "Job",
 				},
 				{
-					Group: "", // NOTICE: The group of Service should be empty, instead of "core"
+					Group: "v1",
 					Kind:  "Service",
 				},
 				{
-					Group: "", // NOTICE: The group of PVC should be empty, instead of "core"
+					Group: "v1",
 					Kind:  "PersistentVolumeClaim",
 				},
 				{
-					Group: "", // NOTICE: The group of Pod should be empty, instead of "core"
+					Group: "v1",
 					Kind:  "Pod",
 				},
 				{
@@ -263,7 +263,7 @@ var _ = Describe("Application Reconciler", func() {
 							Kind:  "Deployment",
 						},
 						{
-							Group: "", // NOTICE: The group of Service should be empty, instead of "core"
+							Group: "v1",
 							Kind:  "Service",
 						},
 					},

--- a/docs/examples/wordpress/application.yaml
+++ b/docs/examples/wordpress/application.yaml
@@ -13,7 +13,7 @@ spec:
     matchLabels:
      app.kubernetes.io/name: "wordpress-01"
   componentKinds:
-    - group: ""
+    - group: v1
       kind: Service
     - group: apps
       kind: StatefulSet

--- a/e2e/wordpress_test.go
+++ b/e2e/wordpress_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Application status should be updated", func() {
 
 		list := &unstructured.UnstructuredList{}
 		list.SetGroupVersionKind(schema.GroupVersionKind{
-			Group: "",
+			Group: "v1",
 			Kind:  "Service",
 		})
 		validateComponentOwnerReferences(kubeClient, list, matchingLabels)


### PR DESCRIPTION
The group of Service can be either "v1" or empty (""), but not "core",
so as other resources (ConfigMap, Pod, Secret, PersistentVolumeClaim and
etc.).