### PR TITLE
Update the way to compute resource status

### DIFF
--- a/docs/examples/wordpress/webserver.yaml
+++ b/docs/examples/wordpress/webserver.yaml
@@ -17,7 +17,7 @@ spec:
   selector:
     app.kubernetes.io/name: "wordpress-01"
     app.kubernetes.io/component: "wordpress-webserver"
-  type: LoadBalancer
+  clusterIP: None
 ---
 apiVersion: v1
 kind: Service

--- a/e2e/resources/withcrd/base/service.yaml
+++ b/e2e/resources/withcrd/base/service.yaml
@@ -14,4 +14,4 @@ spec:
   - port: 80
   selector:
     app.kubernetes.io/component: "test-webserver"
-  type: LoadBalancer
+  clusterIP: None


### PR DESCRIPTION
This commit follows the documentation to compute the resource status:
https://docs.google.com/document/d/1RAPC5-LCb_VBpzvbpCLn8Z-7eilRAWmO0RGbVuChhPc/edit#heading=h.rqs3jxocuzbw

Instead of extracting fields from unstructured, it converts unstructured to corresponding object first.