### PR TITLE
Update golangci-lint to the latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ install:
 -
 
 script:
-# enable golangci-lint check when the code is migrated to kubebuilder v2.0, which is a simplified version
-#- curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
-#- golangci-lint run --enable=gofmt --enable=goimports --enable=unparam --enable=nakedret
-
 # Ensure Build works and unit tests pass
 - make
 # Run e2e tests

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ $(TOOLBIN)/controller-gen:
 	GOBIN=$(TOOLBIN) GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5
 
 $(TOOLBIN)/golangci-lint:
-	GOBIN=$(TOOLBIN) GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.19.1
+	GOBIN=$(TOOLBIN) GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.23.6
 
 $(TOOLBIN)/mockgen:
 	GOBIN=$(TOOLBIN) GO111MODULE=on go get github.com/golang/mock/mockgen@v1.3.1


### PR DESCRIPTION
Golangci-lint failed intermittently on travis Mac OS.
https://travis-ci.org/kubernetes-sigs/application/jobs/650588417?utm_medium=notification&utm_source=github_status
https://travis-ci.org/kubernetes-sigs/application/builds/650452790?utm_source=github_status&utm_medium=notification
....

The speed of the latest version seems to increase a lot per
https://github.com/golangci/golangci-lint/issues/685#issuecomment-541886167.