### PR TITLE
Add columns printer for kubectl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 # Releases should modify and double check these vars.
-REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
-IMAGE_NAME ?= application-controller
-CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= dev
 ARCH ?= amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
+IMAGE_NAME ?= kubernetes-application-$(ARCH)
+TAG ?= dev
+REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
+CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME):$(TAG)
 
 # Directories.
 TOOLS_DIR := $(shell pwd)/hack/tools
@@ -164,7 +164,7 @@ uninstall: $(TOOLBIN)/kustomize
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 .PHONY: deploy
 deploy: $(TOOLBIN)/kustomize
-	cd config/manager && $(TOOLBIN)/kustomize edit set image controller=$(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	cd config/manager && $(TOOLBIN)/kustomize edit set image controller=$(CONTROLLER_IMG)
 	$(TOOLBIN)/kustomize build config/default | kubectl apply -f -
 
 # unDeploy controller in the configured Kubernetes cluster in ~/.kube/config
@@ -220,13 +220,13 @@ generate-go: $(TOOLBIN)/controller-gen $(TOOLBIN)/conversion-gen  $(TOOLBIN)/moc
 
 .PHONY: docker-build
 docker-build: test $(TOOLBIN)/kustomize ## Build the docker image for controller-manager
-	docker build --network=host --pull --build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	docker build --network=host --pull --build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)
 	@echo "updating kustomize image patch file for manager resource"
-	cd config/manager && $(TOOLBIN)/kustomize edit set image controller=$(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	cd config/manager && $(TOOLBIN)/kustomize edit set image controller=$(CONTROLLER_IMG)
 
 .PHONY: docker-push
 docker-push: ## Push the docker image
-	docker push $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	docker push $(CONTROLLER_IMG)
 
 .PHONY: clean
 clean:

--- a/api/v1beta1/application_types.go
+++ b/api/v1beta1/application_types.go
@@ -145,6 +145,9 @@ type ApplicationStatus struct {
 	// Resources embeds a list of object statuses
 	// +optional
 	ComponentList `json:",inline,omitempty"`
+	// ComponentsReady: status of the components in the format ready/total
+	// +optional
+	ComponentsReady string `json:"componentsReady,omitempty"`
 }
 
 // ImageSpec contains information about an image used as an icon.
@@ -293,7 +296,13 @@ const (
 )
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all,shortName=app
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Type",type=string,description="The type of the application",JSONPath=`.spec.descriptor.type`,priority=0
+// +kubebuilder:printcolumn:name="Version",type=string,description="The creation date",JSONPath=`.spec.descriptor.version`,priority=0
+// +kubebuilder:printcolumn:name="Owner",type=boolean,description="The application object owns the matched resources",JSONPath=`.spec.addOwnerRef`,priority=0
+// +kubebuilder:printcolumn:name="Ready",type=string,description="Numbers of components ready",JSONPath=`.status.componentsReady`,priority=0
+// +kubebuilder:printcolumn:name="Age",type=date,description="The creation date",JSONPath=`.metadata.creationTimestamp`,priority=0
 
 // Application is the Schema for the applications API
 type Application struct {

--- a/config/crd/bases/app.k8s.io_applications.yaml
+++ b/config/crd/bases/app.k8s.io_applications.yaml
@@ -11,11 +11,36 @@ metadata:
   creationTimestamp: null
   name: applications.app.k8s.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.descriptor.type
+    description: The type of the application
+    name: Type
+    type: string
+  - JSONPath: .spec.descriptor.version
+    description: The creation date
+    name: Version
+    type: string
+  - JSONPath: .spec.addOwnerRef
+    description: The application object owns the matched resources
+    name: Owner
+    type: boolean
+  - JSONPath: .status.componentsReady
+    description: Numbers of components ready
+    name: Ready
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The creation date
+    name: Age
+    type: date
   group: app.k8s.io
   names:
+    categories:
+    - all
     kind: Application
     listKind: ApplicationList
     plural: applications
+    shortNames:
+    - app
     singular: application
   scope: Namespaced
   subresources:
@@ -442,6 +467,10 @@ spec:
                     type: string
                 type: object
               type: array
+            componentsReady:
+              description: 'ComponentsReady: status of the components in the format
+                ready/total'
+              type: string
             conditions:
               description: Conditions represents the latest state of the object
               items:


### PR DESCRIPTION
fixes #163 

```
$ kubectl get  applications
NAME           TYPE        VERSION   OWNER   READY   AGE
wordpress-01   wordpress   4.9.4     true    5/5     6d13h
```

Also add application as part of the 'all' category and short-name 'app'

