### PR TITLE
Add  kustomize config for prometheus ServiceMonitor

### DIFF
--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -3,3 +3,6 @@
 
 resources:
 - monitor.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/prometheus/kustomizeconfig.yaml
+++ b/config/prometheus/kustomizeconfig.yaml
@@ -1,0 +1,10 @@
+# Copyright 2020 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+# the following config is for teaching kustomize where to look at when substituting vars.
+# It requires kustomize v2.1.0 or newer to work properly.
+
+commonLabels:
+- path: spec/selector
+  create: true
+  kind: ServiceMonitor

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -8,7 +8,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
-  name: controller-manager-metrics-monitor
+  name: metrics-monitor
   namespace: system
 spec:
   endpoints:


### PR DESCRIPTION
ServiceMonitor has a Label selector that wasn't updated after kustomize transformations. 