### PR TITLE
Add a e2e test case for backward compatibility test

### DIFF
--- a/e2e/resources/app-crd-v0.8.0.yaml
+++ b/e2e/resources/app-crd-v0.8.0.yaml
@@ -1,0 +1,241 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: applications.app.k8s.io
+spec:
+  group: app.k8s.io
+  names:
+    kind: Application
+    plural: applications
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            addOwnerRef:
+              type: boolean
+            assemblyPhase:
+              type: string
+            componentKinds:
+              items:
+                type: object
+              type: array
+            descriptor:
+              properties:
+                description:
+                  type: string
+                icons:
+                  items:
+                    properties:
+                      size:
+                        type: string
+                      src:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - src
+                    type: object
+                  type: array
+                keywords:
+                  items:
+                    type: string
+                  type: array
+                links:
+                  items:
+                    properties:
+                      description:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  type: array
+                maintainers:
+                  items:
+                    properties:
+                      email:
+                        type: string
+                      name:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  type: array
+                notes:
+                  type: string
+                owners:
+                  items:
+                    properties:
+                      email:
+                        type: string
+                      name:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  type: array
+                type:
+                  type: string
+                version:
+                  type: string
+              type: object
+            info:
+              items:
+                properties:
+                  name:
+                    type: string
+                  type:
+                    type: string
+                  value:
+                    type: string
+                  valueFrom:
+                    properties:
+                      configMapKeyRef:
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          key:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      ingressRef:
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          host:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          path:
+                            type: string
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      secretKeyRef:
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          key:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      serviceRef:
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          path:
+                            type: string
+                          port:
+                            format: int32
+                            type: integer
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      type:
+                        type: string
+                    type: object
+                type: object
+              type: array
+            selector:
+              type: object
+          type: object
+        status:
+          properties:
+            components:
+              items:
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  link:
+                    type: string
+                  name:
+                    type: string
+                  status:
+                    type: string
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/e2e/testutil/customresource.go
+++ b/e2e/testutil/customresource.go
@@ -17,13 +17,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-// CreateCRD - create application CRD
-func CreateCRD(kubeClient apiextcs.Interface, crd *apiextensions.CustomResourceDefinition) error {
+// CreateOrUpdateCRD - create or update application CRD
+func CreateOrUpdateCRD(kubeClient apiextcs.Interface, crd *apiextensions.CustomResourceDefinition) error {
 
-	_, err := kubeClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.Name, metav1.GetOptions{})
+	currentCrd, err := kubeClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.Name, metav1.GetOptions{})
 
 	if err == nil {
 		// CustomResourceDefinition already exists -> Update
+
+		// Bypass the 'metadata.resourceVersion: Invalid value: 0x0: must be specified for an update' error
+		crd.ResourceVersion = currentCrd.ResourceVersion
 		_, err = kubeClient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(crd)
 		if err != nil {
 			return err


### PR DESCRIPTION
The test is to guarantee that existing application CR objects also work with new Application CRD and controller.
The old_app_crd.yaml was from version `v0.8.0`, which was released before we migrated to kubebuild 2.x.