### PR TITLE
Fix for example kustomize secretGenerator from envs to env

### DIFF
--- a/docs/examples/wordpress/kustomization.yaml
+++ b/docs/examples/wordpress/kustomization.yaml
@@ -22,5 +22,4 @@ resources:
 secretGenerator:
 - name: mysql-pass
   type: Opaque
-  envs:
-  - secrets.txt
+  env: secrets.txt


### PR DESCRIPTION
The values for secretGenereator in the kuztomization.yaml seemed to need a String vs array. Updated it to use   env: path   vs   envs: -path