### PR TITLE
Remove inactive members from OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,7 +14,6 @@ aliases:
     - bryanl
     - garethr
     - pwittrock
-    - adamreese
     - bacongobbler
     - jascott1
     - mattfarina


### PR DESCRIPTION
For kubernetes/org#2013

As a part of cleaning up inactive members (who haven't been active since
the release of v1.11) from OWNERS, this commit removes adamreese from
the OWNERS_ALIASES file.

/assign @prydonius @janetkuo 
cc @mrbobbytables @adamreese 