### PR TITLE
Remove inactive members from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -26,7 +26,6 @@ aliases:
     - technosophos
     - thomastaylor312
     - vaikas-google
-    - viglesiasce
     - cdrage
     - containscafeine
     - janetkuo


### PR DESCRIPTION
Ref: kubernetes/org#2076

As a part of cleaning up inactive members (who haven't been active since
beginning of 2019) from OWNERS files, this commit removes viglesiasce
from the list of reviewers.

cc @viglesiasce @mrbobbytables 
/kind cleanup

/assign @mattfarina 