### PR TITLE
fix: the service status of the loadbalancer type is incorrectly calculated

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -194,7 +194,7 @@ func serviceStatus(u *unstructured.Unstructured) (string, error) {
 	stype := service.Spec.Type
 
 	if stype == corev1.ServiceTypeClusterIP || stype == corev1.ServiceTypeNodePort || stype == corev1.ServiceTypeExternalName ||
-		stype == corev1.ServiceTypeLoadBalancer && isEmpty(service.Spec.ClusterIP) &&
+		stype == corev1.ServiceTypeLoadBalancer && !isEmpty(service.Spec.ClusterIP) &&
 			len(service.Status.LoadBalancer.Ingress) > 0 && !hasEmptyIngressIP(service.Status.LoadBalancer.Ingress) {
 		return StatusReady, nil
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When calculating the status of a loadbalancer service, it returns InProgress, but my service is Ready. the reason is function isEmpty returns false.
```
isEmpty(service.Spec.ClusterIP)
```
But, If the service type is loadBalancer, the clusterIP should not be empty, this pr fix it

**Which issue(s) this PR fixes**:
Fixes #226

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```