### PR TITLE
Update kube-rbac-proxy image version

### DIFF
--- a/deploy/kube-app-manager-aio.yaml
+++ b/deploy/kube-app-manager-aio.yaml
@@ -749,7 +749,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.21.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
The container image of kube-rbac-proxy is no longer available using the old image coordinates. On top of that, an update to the software version makes sense.